### PR TITLE
Update for compatible Bitcoin version, matching `pyln-client` and `pyln-testing` to lightningd version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: Integration Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: Integration Tests 
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bitcoin-version: ["24.0.1", "23.1"]
+        lightningd-version: ["master", "v23.02", "v22.11.1"]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Build Docker image
+      run: |
+        docker build --build-arg LIGHTNINGD_VERSION=${{ matrix.lightningd-version }} \
+                     --build-arg BITCOIN_VERSION=${{ matrix.bitcoin-version }} \
+                     -t cl-test .
+      
+    - name: Run Integration Tests 
+      run: docker run -v $(pwd):/build cl-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update -qq \
 	wget \
 	&& rm -rf /var/lib/apt/lists/*
 
-ARG BITCOIN_VERSION=0.18.1
+ARG BITCOIN_VERSION=24.0.1
 ENV BITCOIN_TARBALL bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$BITCOIN_TARBALL
 ENV BITCOIN_ASC_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/SHA256SUMS.asc

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,39 +8,36 @@ RUN apt-get update -qq \
 	&& apt-get install -y --no-install-recommends \
 	git build-essential autoconf automake build-essential git libtool libgmp-dev \
 	libsqlite3-dev python3 python3-mako net-tools zlib1g-dev libsodium-dev \
-	gettext apt-transport-https ca-certificates
+	gettext apt-transport-https ca-certificates python3-pip wget 
 
 RUN git clone --recursive https://github.com/ElementsProject/lightning.git /tmp/lightning
 WORKDIR /tmp/lightning
 RUN git checkout $LIGHTNINGD_VERSION
 RUN ./configure --prefix=/tmp/lightning_install --enable-developer --disable-valgrind --enable-experimental-features
-RUN make install
+RUN make -j $(nproc) install
 
 FROM ubuntu:latest as final
 
 COPY --from=builder /tmp/lightning_install/ /usr/local/
+COPY --from=builder /tmp/lightning/ /usr/local/src/lightning/
 
 RUN apt-get update -qq \
-	&& apt-get install -y --no-install-recommends \
-	libsqlite3-dev \
-	zlib1g-dev \
-	libsodium-dev \
-	libgmp-dev \
-	python3 \
-	python3-pip \
-	wget \
-	&& rm -rf /var/lib/apt/lists/*
+ 	&& apt-get install -y --no-install-recommends \
+ 	libsqlite3-dev \
+ 	zlib1g-dev \
+ 	libsodium-dev \
+ 	libgmp-dev \
+ 	python3 \
+ 	python3-pip \
+ 	wget \
+ 	&& rm -rf /var/lib/apt/lists/*
 
 ARG BITCOIN_VERSION=24.0.1
 ENV BITCOIN_TARBALL bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$BITCOIN_TARBALL
-ENV BITCOIN_ASC_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/SHA256SUMS.asc
 
 RUN cd /tmp \
 	&& wget -qO $BITCOIN_TARBALL "$BITCOIN_URL" \
-	&& wget -qO bitcoin.asc "$BITCOIN_ASC_URL" \
-	&& grep $BITCOIN_TARBALL bitcoin.asc | tee SHA256SUMS.asc \
-	&& sha256sum -c SHA256SUMS.asc \
 	&& BD=bitcoin-$BITCOIN_VERSION/bin \
 	&& tar -xzvf $BITCOIN_TARBALL $BD/bitcoin-cli $BD/bitcoind --strip-components=1 \
 	&& cp bin/bitcoind bin/bitcoin-cli /usr/bin/ \
@@ -53,7 +50,10 @@ ENV TEST_DEBUG 1
 ENV DEVELOPER 1
 
 WORKDIR /build
-ADD requirements.txt /tmp/
-RUN pip3 install -r /tmp/requirements.txt
+ADD ci-requirements.txt /tmp/
+
+RUN pip3 install /usr/local/src/lightning/contrib/pyln-client
+RUN pip3 install /usr/local/src/lightning/contrib/pyln-testing
+RUN pip3 install -r /tmp/ci-requirements.txt
 
 CMD ["pytest", "-vvv", "--timeout=600", "-n=4"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# c-lightning Project Template
+# c-lightning Project Template (Updated for Bitcoin 24 and Default CI)
 
 Getting started with a new project can be a daunting task, especially on a
 complex project like a Lightning node. This template tries to get you going as
@@ -67,7 +67,7 @@ make docker-test
 ## Where to go next?
 
 Once you have familiarized yourself with how your tests can be run it's time
-to dig deeper. The followin resources should help you on your journey:
+to dig deeper. The following resources should help you on your journey:
 
  - The c-lightning [Plugin API docs][plugin-docs] describe the communication
    between c-lightning and your plugin.

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-timeout
+pytest-xdist


### PR DESCRIPTION
If this is too much change, I can make a PR that just updates the build version as well.

- Added a matrix build with different versions of bitcoin and lightningd
- Install `pylon-client` and `pyln-testing` from the cloned repo so the versions match
- Update `BITCOIN_VERSION` to 24.0.1
- Remove the SHA256 check, looks like we use PGP keys now
- Fixed a small typo

```bash
$ make docker-test
docker run -ti -v /workspaces/template:/build cl-test
=========================================================================================================================== test session starts ============================================================================================================================
platform linux -- Python 3.10.6, pytest-7.2.2, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /build
plugins: xdist-3.2.0, timeout-2.1.0
timeout: 600.0s
timeout method: signal
timeout func_only: False
[gw0] linux Python 3.10.6 cwd: /build
[gw1] linux Python 3.10.6 cwd: /build
[gw2] linux Python 3.10.6 cwd: /build
[gw3] linux Python 3.10.6 cwd: /build
[gw0] Python 3.10.6 (main, Nov 14 2022, 16:10:14) [GCC 11.3.0]
[gw1] Python 3.10.6 (main, Nov 14 2022, 16:10:14) [GCC 11.3.0]
[gw3] Python 3.10.6 (main, Nov 14 2022, 16:10:14) [GCC 11.3.0]
[gw2] Python 3.10.6 (main, Nov 14 2022, 16:10:14) [GCC 11.3.0]
gw0 [4] / gw1 [4] / gw2 [4] / gw3 [4]
scheduling tests via LoadScheduling

tests/test_plugin.py::test_plugin_rpc_call 
tests/test_plugin.py::test_plugin_start 
tests/test_plugin.py::test_payment 
tests/test_plugin.py::test_plugin_option 
[gw0] [ 25%] PASSED tests/test_plugin.py::test_plugin_start 
[gw1] [ 50%] PASSED tests/test_plugin.py::test_plugin_rpc_call 
[gw3] [ 75%] PASSED tests/test_plugin.py::test_plugin_option 
[gw2] [100%] PASSED tests/test_plugin.py::test_payment 

============================================================================================================================ 4 passed in 48.11s ============================================================================================================================
```